### PR TITLE
Add --disable-download-timeout for MSYS2 pacman, fixups, v1.32.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Ruby Install
         uses: ./
@@ -63,6 +63,7 @@ jobs:
 
       - name: Ruby Install
         uses: ./
+        timeout-minutes: 10
         with:
           ruby-version: ${{ matrix.ruby }}
           mingw: _upgrade_ openssl ragel
@@ -88,12 +89,12 @@ jobs:
 
       - name: update RubyGems for Ruby 2.4 & 2.5
         # Included RubyGems doesn't work with required_ruby_version
-        if: (matrix.ruby >= '2.4') && (matrix.ruby < '2.6')
-        run: gem update --system --no-document
+        if: contains('2.4 2.5', matrix.ruby)
+        run: gem update --system 3.3.14 --no-document
         timeout-minutes: 5
 
       - name: gem install openssl
-        if:   (matrix.ruby >= '2.4') && (matrix.ruby <= '3.2')
+        if:   ((matrix.ruby >= '2.4') && (matrix.ruby <= '3.2')) || (matrix.ruby == 'head')
         run:  gem install openssl -N
 
   plus:
@@ -107,7 +108,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Ruby Install
         uses: ./

--- a/dist/index.js
+++ b/dist/index.js
@@ -385,7 +385,8 @@ const openssl = async () => {
     execSync(`pacman.exe -Udd --noconfirm --noprogressbar ${fn}`)
     grpEnd(msSt)
     mingwPkgs = mingwPkgs.replace(/\bopenssl\b/gi, '').trim()
-  } else if (is2022orLater && ruby.abiVers >= '2.5.0 ')
+  } else if ((is2022orLater && ruby.abiVers >= '2.5.0') || core.getInput('ruby-version') === 'head')
+    // Ruby 'head' uses a custom OpenSSL 3 package
     mingwPkgs = mingwPkgs.replace(/\bopenssl\b/gi, '').trim()
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -396,7 +396,7 @@ const updateGCC = async () => {
 
   msSt = grpSt(`Upgrading gcc for Ruby ${ruby.vers}`)
   checkSpace
-  let gccPkgs = ['', 'binutils', 'crt', 'dlfcn', 'headers', 'libiconv', 'isl', 'make', 'mpc', 'mpfr', 'pkgconf', 'windows-default-manifest', 'libwinpthread', 'libyaml', 'winpthreads', 'zlib', 'gcc-libs', 'gcc']
+  let gccPkgs = ['', 'binutils', 'crt', 'headers', 'libiconv', 'isl', 'make', 'mpc', 'mpfr', 'pkgconf', 'windows-default-manifest', 'libwinpthread', 'libyaml', 'winpthreads', 'zlib', 'gcc-libs', 'gcc']
   execSync(`pacman.exe ${msys2Sync} --nodeps ${args} ${gccPkgs.join(pre)}`)
   grpEnd(msSt)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,14 +327,13 @@ let msys2Pkgs = getInput('msys2')
 
 let pre // package prefix, set in setRuby
 // standard pacman args
-const args  = '--noconfirm --noprogressbar --needed'
+const args  = '--noconfirm --noprogressbar --needed --disable-download-timeout'
 
 // Not used. Installs packages stored in GitHub release.
 // Only needed for exceptional cases.
 const install = async (pkg, release) => {  // eslint-disable-line no-unused-vars
   const uriBase = 'https://github.com/MSP-Greg/ruby-msys2-package-archive/releases/download'
   const suff    = '-any.pkg.tar.xz'
-  const args    = '--noconfirm --noprogressbar --needed'
 
   const uri = `${uriBase}/${release}`
 

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-ruby-pkgs",
-  "version": "1.32.3",
+  "version": "1.32.4",
   "description": "Install packages and update builds tools for Ruby",
   "main": "index.js",
   "scripts": {

--- a/mingw.js
+++ b/mingw.js
@@ -102,7 +102,7 @@ const updateGCC = async () => {
 
   msSt = grpSt(`Upgrading gcc for Ruby ${ruby.vers}`)
   checkSpace
-  let gccPkgs = ['', 'binutils', 'crt', 'dlfcn', 'headers', 'libiconv', 'isl', 'make', 'mpc', 'mpfr', 'pkgconf', 'windows-default-manifest', 'libwinpthread', 'libyaml', 'winpthreads', 'zlib', 'gcc-libs', 'gcc']
+  let gccPkgs = ['', 'binutils', 'crt', 'headers', 'libiconv', 'isl', 'make', 'mpc', 'mpfr', 'pkgconf', 'windows-default-manifest', 'libwinpthread', 'libyaml', 'winpthreads', 'zlib', 'gcc-libs', 'gcc']
   execSync(`pacman.exe ${msys2Sync} --nodeps ${args} ${gccPkgs.join(pre)}`)
   grpEnd(msSt)
 

--- a/mingw.js
+++ b/mingw.js
@@ -91,7 +91,8 @@ const openssl = async () => {
     execSync(`pacman.exe -Udd --noconfirm --noprogressbar ${fn}`)
     grpEnd(msSt)
     mingwPkgs = mingwPkgs.replace(/\bopenssl\b/gi, '').trim()
-  } else if (is2022orLater && ruby.abiVers >= '2.5.0 ')
+  } else if ((is2022orLater && ruby.abiVers >= '2.5.0') || core.getInput('ruby-version') === 'head')
+    // Ruby 'head' uses a custom OpenSSL 3 package
     mingwPkgs = mingwPkgs.replace(/\bopenssl\b/gi, '').trim()
 }
 

--- a/mingw.js
+++ b/mingw.js
@@ -33,14 +33,13 @@ let msys2Pkgs = getInput('msys2')
 
 let pre // package prefix, set in setRuby
 // standard pacman args
-const args  = '--noconfirm --noprogressbar --needed'
+const args  = '--noconfirm --noprogressbar --needed --disable-download-timeout'
 
 // Not used. Installs packages stored in GitHub release.
 // Only needed for exceptional cases.
 const install = async (pkg, release) => {  // eslint-disable-line no-unused-vars
   const uriBase = 'https://github.com/MSP-Greg/ruby-msys2-package-archive/releases/download'
   const suff    = '-any.pkg.tar.xz'
-  const args    = '--noconfirm --noprogressbar --needed'
 
   const uri = `${uriBase}/${release}`
 

--- a/mingw_gcc.js
+++ b/mingw_gcc.js
@@ -28,7 +28,7 @@ export const run = async (rubyVers) => {
   const uriBase = 'https://github.com/MSP-Greg/ruby-msys2-package-archive/releases/download'
   const pre64   = 'mingw-w64-x86_64-'
   const suff    = '-any.pkg.tar.xz'
-  const args    = '--noconfirm --noprogressbar --needed'
+  const args    = '--noconfirm --noprogressbar --needed --disable-download-timeout'
 
   let mingwFiles
   let uri

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-ruby-pkgs",
-  "version": "1.32.3",
+  "version": "1.32.4",
   "description": "Install packages and update builds tools for Ruby",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixups:

1. Ruby head builds with a custom OpenSSL package
2. Don't install dlfcn when gcc is upgraded
3. Update actions/checkout version, missed two previously

Closes #28